### PR TITLE
Fix typo: run arc-create instead of create

### DIFF
--- a/src/shared/docs/en/getting-started/settings.md
+++ b/src/shared/docs/en/getting-started/settings.md
@@ -57,7 +57,7 @@ get /
 
 4. If you haven't already, make sure to go [set up your AWS credentials and env vars (as necessary)](https://arc.codes/quickstart).
 
-5. Run `npx create`
+5. Run `npx arc-create`
 
 That should get you going on AWS without Begin! Of course, you'll probably want to keep going by adding a domain, setting up a database, and more.
 


### PR DESCRIPTION
Please update the documentation, it requires `arc-create`: https://github.com/architect/create/blob/master/package.json#L7