### PR TITLE
Shared-code docs

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -64,6 +64,7 @@ cron
 CSR
 CSRF
 CSS
+css
 CTO
 debuggable
 declaratively
@@ -201,6 +202,7 @@ SSD-backed
 SSD-based
 SSL
 statefulness
+stylesheet
 subdirectories
 subdomain
 subdomains

--- a/src/shared/docs/en/ToC.json
+++ b/src/shared/docs/en/ToC.json
@@ -266,7 +266,8 @@
         "sections": [
           "Overview",
           "The magical `src/shared` and `src/views` directories",
-          "Hydrate"
+          "Hydrate",
+          "Example"
         ]
       }
     ]

--- a/src/shared/docs/en/ToC.json
+++ b/src/shared/docs/en/ToC.json
@@ -256,6 +256,22 @@
     ]
   },
   {
+    "catID": "share-code",
+    "catTitle": "Share code",
+    "docs": [
+      {
+        "docID": "sharing-common-code",
+        "docTitle": "Sharing Common Code",
+        "description": "Share modules, templates, and other files across cloud functions",
+        "sections": [
+          "Overview",
+          "The magical `src/shared` and `src/views` directories",
+          "Hydrate"
+        ]
+      }
+    ]
+  },
+  {
     "catID": "support",
     "catTitle": "Support",
     "docs": [

--- a/src/shared/docs/en/share-code/sharing-common-code.md
+++ b/src/shared/docs/en/share-code/sharing-common-code.md
@@ -2,7 +2,7 @@
 
 Applications tend to share logic, templates, and other assets. Begin gives you a simple, seamless way to share modules, templates, and other files across your project's many functions.
 
-Given the following `.arc` file:
+Given the following `app.arc` file:
 
 ```bash
 @app
@@ -25,7 +25,7 @@ You would have the following file system layout:
 │       ├── get-about/
 │       ├── get-contact/
 │       └── post-contact/
-├── .arc
+├── app.arc
 └── package.json
 ```
 
@@ -49,15 +49,21 @@ Create either or both `src/shared` and `src/views` directories.
   │   │   └── post-contact/
 > │   ├── shared/
 > │   └── views/
-  ├── .arc
+  ├── app.arc
   └── package.json
 ```
 
 In the above example, files found in `src/shared` will be copied into every function's `node_modules/@architect/shared` directory.
 
-Similarly, files found in `src/views` will be copied into only `GET /`, `GET /about`, and `GET /contact`'s `/node_modules/@architect/shared` directories, but not `POST /contact`.
+Similarly, files found in `src/views` will be copied into `/node_modules/@architect/shared` directory as well, but only `GET` handlers and not `POST`:
 
-You can also specify a list of `@http` functions you want `src/views` to target by specifying them in the `@views` section of your `.arc` file. An example of this would look like:
+- `GET /`
+- `GET /about`
+- `GET /contact` 
+
+You can also specify a list of `@http` functions you want `src/views` to target by specifying them in the `@views` section of your `app.arc` file.
+
+An example of this would look like:
 
 ```bash
 @app
@@ -76,15 +82,15 @@ get /
 get /about
 ```
 
-What we've done is added two new routes:
+Here's an example of what we mean. What we've done is added two new routes:
+
 - `/gallery` 
 - `/css/:stylesheet`
 
-We then declared that only two of the routes in this project should receive a copy of the modules in `src/views`.
+We then declared that only two of the routes in this project should receive a copy of the modules in `src/views`:
+
 - `/`  
 - `/about` 
-
-
 
 ## Hydrate
 
@@ -94,7 +100,9 @@ Begin will refresh your functions' shared code whenever you:
 - Run `npx deploy`
 - Run `npx hydrate`
 
-Example: create `src/shared/layout.js`:
+## Example
+
+Create `src/shared/layout.js`:
 
 ```javascript
 module.exports = function layout(body) {

--- a/src/shared/docs/en/share-code/sharing-common-code.md
+++ b/src/shared/docs/en/share-code/sharing-common-code.md
@@ -1,0 +1,118 @@
+## Overview
+
+Applications tend to share logic, templates, and other assets. Begin gives you a simple, seamless way to share modules, templates, and other files across your project's many functions.
+
+Given the following `.arc` file:
+
+```bash
+@app
+testapp
+
+@http
+get /
+get /about
+get /contact
+post /contact
+```
+
+You would have the following file system layout:
+
+```bash
+/
+├── src
+│   └── http
+│       ├── get-index/
+│       ├── get-about/
+│       ├── get-contact/
+│       └── post-contact/
+├── .arc
+└── package.json
+```
+
+Sweet! However, what if a number of endpoints need to share the same layout file, or some middleware?
+
+
+## The magical `src/shared` and `src/views` directories
+
+Create either or both `src/shared` and `src/views` directories. 
+
+- All files within the `src/shared` directory will automatically be available to each of the functions with your project. 
+- All files within the `src/views` directory will be automatically available to all of your `GET` functions.
+
+```bash
+  /
+  ├── src
+  │   ├── http
+  │   │   ├── get-index/
+  │   │   ├── get-about/
+  │   │   ├── get-contact/
+  │   │   └── post-contact/
+> │   ├── shared/
+> │   └── views/
+  ├── .arc
+  └── package.json
+```
+
+In the above example, files found in `src/shared` will be copied into every function's `node_modules/@architect/shared` directory.
+
+Similarly, files found in `src/views` will be copied into just `GET /`, `GET /about`, and `GET /contact`'s `/node_modules/@architect/shared` directories, but not `POST /contact`.
+
+You can also specify a list of `@http` functions you want `src/views` to target by specifying them in the `@views` section of your `.arc` file. An example of this would look like:
+
+```bash
+@app
+testapp
+
+@http
+get /
+get /about
+get /contact
+post /contact
+
+@views
+get /about
+```
+
+What we've done is added two new routes - /about and /css/:stylesheet, then declared that two of the routes / and /about should receive a copy of the modules in src/views.
+
+## Hydrate
+
+Begin will refresh your functions' shared code whenever you:
+
+- Start up `npx sandbox` (or `arc.sandbox` in tests)
+- Run `npx deploy`
+- Run `npx hydrate`
+
+Example: create `src/shared/layout.js`:
+
+```javascript
+module.exports = function layout(body) {
+  return `
+  <html>
+    <body>
+      <h1>layout</h1>
+      ${body}
+    </body>
+  </html>
+  `
+}
+```
+
+And then in your Lambda handlers you can reference `@architect/shared/layout` like so:
+
+```javascript
+let layout = require('@architect/shared/layout')
+
+exports.handler = async function http(req) {
+  return {
+    body: layout('hello world')
+  }
+}
+```
+
+Anytime you preview locally, run tests, or deploy the layout, your shared modules get updated. 
+
+> Caution! Since `src/shared` gets copied recursively into all Lambdas' node_modules we strongly suggest keeping the directory structure as flat as possible, and the payloads as small possible, so as not bloat your Lambda functions and suffer worse cold starts.
+
+
+

--- a/src/shared/docs/en/share-code/sharing-common-code.md
+++ b/src/shared/docs/en/share-code/sharing-common-code.md
@@ -36,7 +36,7 @@ Sweet! However, what if a number of endpoints need to share the same layout file
 
 Create either or both `src/shared` and `src/views` directories. 
 
-- All files within the `src/shared` directory will automatically be available to each of the functions with your project. 
+- All files within the src/shared directory will automatically be available to each of your project's functions.
 - All files within the `src/views` directory will be automatically available to all of your `GET` functions.
 
 ```bash
@@ -55,7 +55,7 @@ Create either or both `src/shared` and `src/views` directories.
 
 In the above example, files found in `src/shared` will be copied into every function's `node_modules/@architect/shared` directory.
 
-Similarly, files found in `src/views` will be copied into just `GET /`, `GET /about`, and `GET /contact`'s `/node_modules/@architect/shared` directories, but not `POST /contact`.
+Similarly, files found in `src/views` will be copied into only `GET /`, `GET /about`, and `GET /contact`'s `/node_modules/@architect/shared` directories, but not `POST /contact`.
 
 You can also specify a list of `@http` functions you want `src/views` to target by specifying them in the `@views` section of your `.arc` file. An example of this would look like:
 
@@ -67,13 +67,24 @@ testapp
 get /
 get /about
 get /contact
+get /gallery
+get /css/:stylesheet
 post /contact
 
 @views
+get /
 get /about
 ```
 
-What we've done is added two new routes - /about and /css/:stylesheet, then declared that two of the routes / and /about should receive a copy of the modules in src/views.
+What we've done is added two new routes:
+- `/gallery` 
+- `/css/:stylesheet`
+
+We then declared that only two of the routes in this project should receive a copy of the modules in `src/views`.
+- `/`  
+- `/about` 
+
+
 
 ## Hydrate
 


### PR DESCRIPTION
Added new section explaining `src/shared` & `src/views` directories and how to share code to HTTP functions.